### PR TITLE
feat: Enhance Maven plugin with new actions and utilities

### DIFF
--- a/lua/maven/actions/add_dependency_to_pom.lua
+++ b/lua/maven/actions/add_dependency_to_pom.lua
@@ -1,0 +1,115 @@
+local M = {}
+
+local utils = require("maven.utils")
+local config = require("maven.config")
+
+function M.add_dependency_to_pom()
+  -- Function that defines the command to open Maven Central according to the OS
+  local function get_open_command(os_name)
+    local url = config.options.maven_central_url
+    if os_name == "Linux" or os_name == "FreeBSD" or os_name == "OpenBSD" or os_name == "NetBSD" then
+      return { "xdg-open", url }, nil
+    elseif os_name == "Darwin" then
+      return { "open", url }, nil
+    elseif os_name == "Windows_NT" then
+      return { "cmd.exe", "/C", "start", url }, nil
+    else
+      return nil, "Unsupported OS"
+    end
+  end
+
+  utils.open_maven_central(get_open_command)
+
+  local buf, win = utils.create_floating_window()
+
+  local function remove_instruction()
+    utils.remove_instruction(buf, win)
+  end
+
+  -- Function to remove instruction message
+  vim.defer_fn(function()
+    vim.api.nvim_create_autocmd({ "TextChangedI", "TextChanged", "TextChangedP" }, {
+      buffer = buf,
+      callback = function()
+        remove_instruction()
+      end,
+    })
+  end, 500)
+
+  -- Maps <enter> to close the window and capture the content
+  vim.api.nvim_buf_set_keymap(buf, "n", "<CR>", "", {
+    noremap = true,
+    callback = function()
+      local lines_dependency = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      local dependency = table.concat(lines_dependency, "\n")
+
+      if dependency == "" then
+        vim.notify("No dependency provided", vim.log.levels.WARN)
+        return
+      end
+
+      local function get_cwd()
+        return require("maven.config").options.cwd or vim.fn.getcwd()
+      end
+
+      local pom_file = get_cwd() .. "/pom.xml"
+
+      -- Read the contents of pom.xml
+      local pom_content = table.concat(vim.fn.readfile(pom_file), "\n")
+
+      local function normalize_string(str)
+        return str:gsub("%s+", " "):gsub("^%s*(.-)%s*$", "%1")
+      end
+
+      -- Function to check if the dependency is already present
+      local function is_dependency_present(p_content, dep)
+        local normalized_dependency = normalize_string(dep)
+        local normalized_pom_content = normalize_string(p_content)
+        return normalized_pom_content:find(normalized_dependency, 1, true) ~= nil
+      end
+
+      if is_dependency_present(pom_content, dependency) then
+        vim.notify("Dependency already exists in pom.xml", vim.log.levels.INFO)
+        return
+      end
+
+      local lines = {}
+      for line in io.lines(pom_file) do
+        table.insert(lines, line)
+      end
+
+      local insert_index = nil
+      for i, line in ipairs(lines) do
+        if line:find("</dependencies>") then
+          insert_index = i
+          break
+        end
+      end
+
+      if insert_index then
+        local formatted_dependency =
+          dependency:gsub("\n%s*<", "\n      <"):gsub("\n%s*</dependency>", "\n    </dependency>")
+        table.insert(lines, insert_index, "    " .. formatted_dependency)
+      else
+        vim.notify("No </dependencies> tag found in pom.xml", vim.log.levels.ERROR)
+        return
+      end
+
+      local file = io.open(pom_file, "w")
+      if not file then
+        vim.notify("Failed to open pom.xml for writing", vim.log.levels.ERROR)
+        return
+      end
+
+      for _, line in ipairs(lines) do
+        file:write(line .. "\n")
+      end
+      file:close()
+
+      vim.notify("Dependency added to pom.xml", vim.log.levels.INFO)
+      vim.api.nvim_win_close(win, true)
+    end,
+  })
+end
+
+return M

--- a/lua/maven/actions/create_project.lua
+++ b/lua/maven/actions/create_project.lua
@@ -1,0 +1,32 @@
+local M = {}
+
+-- on create project maven
+function M.create_project(callback)
+  local default_group_id = "com.javaexample"
+  local default_artifact_id = "javaexample"
+  local default_archetype_id = "maven-archetype-quickstart"
+
+  -- Prompts user for input
+  -- Checks whether the entered value is nil or empty, and applies the pattern if necessary
+  vim.ui.input({ prompt = "GroupId: (default: " .. default_group_id .. ")" }, function(groupId)
+    groupId = (groupId ~= nil and groupId ~= "") and groupId or default_group_id
+    vim.ui.input({ prompt = "ArtifactId: (default: " .. default_artifact_id .. ")" }, function(artifactId)
+      artifactId = (artifactId ~= nil and artifactId ~= "") and artifactId or default_artifact_id
+
+      vim.ui.input({ prompt = "ArchetypeId: (default: " .. default_archetype_id .. ")" }, function(archetypeId)
+        archetypeId = (archetypeId ~= nil and archetypeId ~= "") and archetypeId or default_archetype_id
+
+        local cmd = string.format(
+          "archetype:generate -DgroupId=%s -DartifactId=%s -DarchetypeArtifactId=%s -DinteractiveMode=false",
+          groupId,
+          artifactId,
+          archetypeId
+        )
+        -- Retorna o comando para o callback
+        callback({ cmd = cmd })
+      end)
+    end)
+  end)
+end
+
+return M

--- a/lua/maven/actions/init.lua
+++ b/lua/maven/actions/init.lua
@@ -1,0 +1,5 @@
+local M = {}
+
+M.create_project = require("maven.actions.create_project").create_project
+M.add_dependency_to_pom = require("maven.actions.add_dependency_to_pom").add_dependency_to_pom
+return M

--- a/lua/maven/commands.lua
+++ b/lua/maven/commands.lua
@@ -1,3 +1,5 @@
+local actions = require("maven.actions")
+
 local commands = {
   ---@class MavenCommandOption
   ---@field cmd string[]
@@ -11,6 +13,8 @@ local commands = {
   { cmd = { "install" } },
   { cmd = { "site" } },
   { cmd = { "deploy" } },
+  { cmd = { "add-dependency" }, desc = "Open Maven Central and add dependency" },
+  { cmd = actions.create_project, desc = "Create Maven Project" },
 }
 
 return commands

--- a/lua/maven/config.lua
+++ b/lua/maven/config.lua
@@ -6,16 +6,18 @@ M.namespace = vim.api.nvim_create_namespace("Maven")
 ---@field executable string
 ---@field cwd string|nil
 ---@field settings string|nil
+---@field maven_central_url string|nil
 ---@field commands MavenCommandOption[]|nil
 local defaults = {
   executable = "./mvnw", -- `mvn` should be in your `PATH`, or the absolute path or the maven exectable, or `./mvnw`
   cwd = nil, -- work directory, default to `vim.fn.getcwd()`
   settings = nil, -- specify the settings file or use the default settings
   commands = nil, -- add custom goals to the command list
+  maven_central_url = "https://central.sonatype.com/", -- https://mvnrepository.com/repos/central
 }
 
 ---@type MavenOptions
-M.options = {}
+M.options = vim.tbl_deep_extend("force", {}, defaults)
 ---@return MavenOptions
 
 function M.setup(options)

--- a/lua/maven/utils/create_floating_window.lua
+++ b/lua/maven/utils/create_floating_window.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+local message = "Paste the dependency here and press enter to add it to the pom.xml."
+
+-- Function to create the floating window where the user will paste the dependency
+function M.create_floating_window()
+  local buf = vim.api.nvim_create_buf(false, true)
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = 80,
+    height = 10,
+    row = 10,
+    col = 10,
+    style = "minimal",
+    border = "rounded",
+  })
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, { message, "" })
+  vim.api.nvim_win_set_cursor(win, { 2, 0 })
+
+  return buf, win
+end
+
+-- Function to remove instruction message when user starts typing
+function M.remove_instruction(buf, win)
+  local first_line = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+  if first_line == message then
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, {})
+    vim.api.nvim_win_set_cursor(win, { 1, 0 })
+  end
+end
+
+return M

--- a/lua/maven/utils/init.lua
+++ b/lua/maven/utils/init.lua
@@ -1,0 +1,6 @@
+local M = {}
+
+M.create_floating_window = require("maven.utils.create_floating_window").create_floating_window
+M.remove_instruction = require("maven.utils.create_floating_window").remove_instruction
+M.open_maven_central = require("maven.utils.open_maven_central").open_maven_central
+return M

--- a/lua/maven/utils/open_maven_central.lua
+++ b/lua/maven/utils/open_maven_central.lua
@@ -1,0 +1,23 @@
+local M = {}
+
+-- Function to open the Maven Central website
+function M.open_maven_central(get_open_command)
+  ---@diagnostic disable-next-line: undefined-field
+  local os_name = vim.loop.os_uname().sysname
+  local cmd, err = get_open_command(os_name)
+
+  if not cmd then
+    vim.notify(err or "Unknown error", vim.log.levels.ERROR)
+    return
+  end
+
+  -- Execute the command in non-blocking mode
+  ---@diagnostic disable-next-line: undefined-field
+  vim.loop.spawn(cmd[1], { args = { cmd[2], cmd[3], cmd[4] } }, function(code, _)
+    if code ~= 0 then
+      vim.notify("Failed to open URL", vim.log.levels.ERROR)
+    end
+  end)
+end
+
+return M

--- a/lua/maven/validate.lua
+++ b/lua/maven/validate.lua
@@ -1,0 +1,47 @@
+local M = {}
+
+-- Checks if there is a pom.xml file in the directory
+local function has_build_file(cwd)
+  return vim.fn.findfile("pom.xml", cwd) ~= ""
+end
+
+-- Checks whether a tag with specific content is present in pom.xml
+local function has_required_tag_in_pom(cwd, tag, content)
+  local pom_file = cwd .. "/pom.xml"
+  -- Checks if the file exists
+  if vim.fn.filereadable(pom_file) == 0 then
+    return false
+  end
+  -- Read the contents of the pom.xml file
+  local pom_content = table.concat(vim.fn.readfile(pom_file), "\n")
+  -- Checks if the tag with the content is present
+  local pattern = "<" .. tag .. ">%s*" .. content:gsub("%s+", "%%s*") .. "%s*</" .. tag .. ">"
+  return pom_content:match(pattern) ~= nil
+end
+
+-- validation to check conditions before executing the command
+function M.validate(cmd, cwd)
+  if type(cmd.cmd) ~= "table" or not cmd.cmd[1] then
+    return false, "Invalid command structure."
+  end
+
+  if cmd.cmd[1] ~= "archetype:generate" and not has_build_file(cwd) then
+    return false, "No pom.xml file found under " .. cwd
+  end
+  if cmd.cmd[1] == "archetype:generate" then
+    if has_build_file(cwd) then
+      if has_required_tag_in_pom(cwd, "packaging", "pom") then
+        return true, "Required tag found in pom.xml. Proceeding with Maven multi-module project creation."
+      else
+        return false,
+          "There is a pom.xml file indicating that there is already a Maven project in the directory: " .. cwd
+      end
+    else
+      return true, "No existing pom.xml found. Proceeding to create a new Maven project."
+    end
+  end
+
+  return true, "Command is valid and can be executed."
+end
+
+return M

--- a/lua/maven/view.lua
+++ b/lua/maven/view.lua
@@ -88,6 +88,7 @@ function View:setup()
     pattern = "maven",
     callback = function()
       if self.job and self.job.pid then
+        ---@diagnostic disable-next-line: undefined-field
         uv.kill(self.job.pid, 15)
       end
     end,


### PR DESCRIPTION
This pull request introduces several enhancements and new functionalities to the Maven plugin, improving its usability and extending its capabilities. The following changes have been made:

New Features:

add_dependency_to_pom.lua: Added functionality to facilitate the addition of dependencies directly to the pom.xml file, streamlining the process for users.
create_project.lua: Introduced a new action to create Maven projects more efficiently, providing a user-friendly experience.
init.lua: Included initialization routines for the new action scripts, ensuring proper setup and integration.
create_floating_window.lua: Added utility to create floating windows for user inputs, enhancing the plugin's interface.
open_maven_central.lua: Implemented a utility function to open Maven Central, allowing users to easily access repositories and dependencies.
validate.lua: Created a validation module to check configurations and ensure correct setup.
Modifications:

commands.lua: Updated command definitions to incorporate the new functionalities, making it easier for users to execute Maven-related tasks.
config.lua: Modified configuration settings to include a new field for specifying the Maven Central URL, allowing for customization.
init.lua: Adjusted initialization logic to accommodate the new utilities and actions, improving overall plugin performance.

if you want to test before merging:

```lua
 {
    'glaulher/maven.nvim',
    branch = 'newfeat',
    cmd = { 'Maven', 'MavenExec' },
    dependencies = 'nvim-lua/plenary.nvim',
    config = function()
      require('maven').setup {
        executable = 'mvn',
        -- maven_central_url = 'https://mvnrepository.com/repos/central', if nil https://central.sonatype.com/
      }
    end,
  },

```