### PR TITLE
feat: make the custom added goals top of goals command list

### DIFF
--- a/lua/maven/init.lua
+++ b/lua/maven/init.lua
@@ -20,7 +20,7 @@ function maven.setup(options)
   config.setup(options)
   if config.options.commands ~= nil then
     for _, command in pairs(config.options.commands) do
-      table.insert(commands, command)
+      table.insert(commands, 1, command)
     end
   end
 end


### PR DESCRIPTION
Hello!

I would like to make the custom added commands/goals on top of the list, the once I add manually is probably the ones I normally use.

What do you think?